### PR TITLE
Add CMS setup for editable menu and gallery

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,24 @@
+backend:
+  name: github
+  repo: SamGamgy/kneaded-bakery-site
+  branch: main
+publish_mode: editorial_workflow
+media_folder: images/uploads
+public_folder: /images/uploads
+collections:
+  - name: "menu"
+    label: "Menu Page"
+    files:
+      - file: "menu.html"
+        label: "Menu"
+        name: "menu"
+        editor:
+          preview: false
+  - name: "gallery"
+    label: "Gallery Page"
+    files:
+      - file: "gallery.html"
+        label: "Gallery"
+        name: "gallery"
+        editor:
+          preview: false

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Kneaded Bakery Content Manager</title>
+</head>
+<body>
+  <!-- Include the script that powers Netlify CMS -->
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds the Static CMS (Netlify CMS) configuration and admin interface files. It introduces `admin/config.yml` with GitHub backend and editorial workflow, and `admin/index.html` to load the CMS. This will allow content to be edited via a user-friendly UI at /admin, including the menu and gallery pages.