### PR TITLE
Add fields to config.yml for menu and gallery

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -14,6 +14,10 @@ collections:
         name: "menu"
         editor:
           preview: false
+        fields:
+          - label: "Menu Content"
+            name: "body"
+            widget: "markdown"
   - name: "gallery"
     label: "Gallery Page"
     files:
@@ -22,3 +26,7 @@ collections:
         name: "gallery"
         editor:
           preview: false
+        fields:
+          - label: "Gallery Content"
+            name: "body"
+            widget: "markdown"


### PR DESCRIPTION
This PR updates the Netlify CMS config.yml to include the required 'fields' definitions for the menu and gallery pages. Without these fields, the CMS cannot load, resulting in errors. Adding these fields allows editing of the full page content for both pages.